### PR TITLE
Upgraded react-scripts dependency to the latest v1.1.1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "semantic-ui-css": "^2.2.10"
   },
   "devDependencies": {
-    "react-scripts": "0.9.5"
+    "react-scripts": "1.1.1"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
This fixes the following error on macOS with regards to and fsevents@1.0.17 not being found when using Node.js 8+. See issues and pull requests: facebook/create-react-app#2613 facebook/create-react-app#2550 strongloop/fsevents#170 strongloop/fsevents#169.

A minimum verison of v1.0.8 is required as the PR was pushed in that release: https://github.com/facebook/create-react-app/releases/tag/v1.0.8

Considering the targeted nature of the project, I figured that upgrading to the latest (v1.1.1) would be safe.